### PR TITLE
Reimplement Google Analytics with consent to false by default

### DIFF
--- a/layouts/partials/google_analytics.html
+++ b/layouts/partials/google_analytics.html
@@ -1,0 +1,62 @@
+{{- $pc := .Site.Config.Privacy.GoogleAnalytics -}}
+{{- if not $pc.Disable }}{{ with .Site.GoogleAnalytics -}}
+    {{ if hasPrefix . "G-"}}
+      <script async src="https://www.googletagmanager.com/gtag/js?id={{ . }}"></script>
+      <script>
+          {{ template "__ga_js_set_doNotTrack" $ }}
+          {{- $pcGa := site.Params.Privacy.GoogleAnalytics}}
+          if (!doNotTrack) {
+            window.dataLayer = window.dataLayer || [];
+            function gtag(){dataLayer.push(arguments);}
+              {{- if $pcGa.defaultGtagStorageDenied }}
+            gtag('consent', 'default', {
+              ad_storage: 'denied',
+              analytics_storage: 'denied',
+              {{- if $pcGa.WaitForUpdate }}
+              wait_for_update: {{ $pcGa.WaitForUpdate }},
+              {{- end }}
+              region: ['US-CA', 'BE', 'BG', 'CZ', 'DK', 'DE', 'EE', 'IE', 'GR', 'ES', 'FR', 'HR', 'IT', 'CY', 'LV', 'LT', 'LU', 'HU', 'MT', 'NL', 'AT', 'PL', 'PT', 'RO', 'SI', 'SK', 'FI', 'SE']
+            });
+              {{- end }}
+            gtag('js', new Date());
+            gtag('config', '{{ . }}', { 'anonymize_ip': {{- $pc.AnonymizeIP -}} });
+          }
+      </script>
+    {{ else if hasPrefix . "UA-" }}
+      <script type="application/javascript">
+          {{ template "__ga_js_set_doNotTrack" $ }}
+          if (!doNotTrack) {
+            (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+              (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+              m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+            })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
+              {{- if $pc.UseSessionStorage }}
+            if (window.sessionStorage) {
+              var GA_SESSION_STORAGE_KEY = 'ga:clientId';
+              ga('create', '{{ . }}', {
+                'storage': 'none',
+                'clientId': sessionStorage.getItem(GA_SESSION_STORAGE_KEY)
+              });
+              ga(function(tracker) {
+                sessionStorage.setItem(GA_SESSION_STORAGE_KEY, tracker.get('clientId'));
+              });
+            }
+              {{ else }}
+            ga('create', '{{ . }}', 'auto');
+              {{ end -}}
+              {{ if $pc.AnonymizeIP }}ga('set', 'anonymizeIp', true);{{ end }}
+            ga('send', 'pageview');
+          }
+      </script>
+    {{- end -}}
+{{- end }}{{ end -}}
+
+{{- define "__ga_js_set_doNotTrack" -}}{{/* This is also used in the async version. */}}
+{{- $pc := .Site.Config.Privacy.GoogleAnalytics -}}
+{{- if not $pc.RespectDoNotTrack -}}
+  var doNotTrack = false;
+{{- else -}}
+  var dnt = (navigator.doNotTrack || window.doNotTrack || navigator.msDoNotTrack);
+  var doNotTrack = (dnt == "1" || dnt == "yes");
+{{- end -}}
+{{- end -}}

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -53,4 +53,4 @@
 {{ template "_internal/twitter_cards.html" . }}
 
 <!-- google analytics -->
-{{ template "_internal/google_analytics.html" . }}
+{{ partial "google_analytics.html" . }}


### PR DESCRIPTION
Reimplemented Google Analytics with consent management to off in places where it applies.

Original template comes from [Hugo internal template](https://github.com/gohugoio/hugo/blob/master/tpl/tplimpl/embedded/templates/google_analytics.html), with a modification inspired by [this open PR in Hugo](https://github.com/gohugoio/hugo/pull/9340).

I followed [Google's documentation](https://developers.google.com/tag-platform/devguides/consent) for this.

This feature is turned off by default. To turn it on, the following configs need to be set up in Hugo:

```yml
params:
    privacy:
        googleAnalytics:
            defaultGtagStorageDenied: true
            waitForUpdate: 500
```

The `WaitForUpdate` is intended to make the script wait 500 milliseconds before sending the ping to GA, in order to provide enough time for a consent update instruction to be executed later in the code, should the user provide consent for tracking cookies:

```js
gtag('consent', 'update', {
  'analytics_storage': 'granted'
});
```

This however needs to be implemented in a follow-up PR, because we don't have a consent banner yet.